### PR TITLE
Add Windows Instructions to BuildingAndRunning.md

### DIFF
--- a/doc/BuildingAndRunning.md
+++ b/doc/BuildingAndRunning.md
@@ -22,6 +22,14 @@ On Arch Linux:
 On Mac via Homebrew:
 
     brew install cmake git ninja
+    
+On Windows:
+
+    You will need to install Visual Studios with following Spectre-migrated libraries
+    You can find these in the Visual Studio Installer under Individual components
+    > MSVC v142 - VS 2019 C++ x64/x86 Spectre-migrated libs (Latest)
+    > C++ ATL for latest v142 build tools with Spectre Mitigations (ARM64)
+    > C++ ATL for latest v142 build tools with Spectre Mitigations (x68 & x64)
 
 ## Building on Linux and macOS
 
@@ -53,6 +61,11 @@ The above instructions create an unoptimized debug build. The `--distribute` fla
     cd build_release && ninja
 
 ## Building on Windows
+
+You should be able to build hermes by running the following script from the base of the repository.
+Note: There may be errors shown on the script but hermes is built if you can find the executable in build/bin/hermes/Debug/hermes.exe
+    
+    .ado\scripts\cibuild.ps1
 
 The Windows build depends on which particular combination of GitBash/Cygwin/WSL and Visual Studio is used.
 


### PR DESCRIPTION
While working in the hermes-windows repository, there was a lack of current documentation needed to run hermes. This PR hopes to mitigate this issue for the next person onboarding into this repository.

Let me know if there's a better place for this! :)
